### PR TITLE
Optimize memory usage

### DIFF
--- a/bintest/rcheck-analyzer.rb
+++ b/bintest/rcheck-analyzer.rb
@@ -69,15 +69,12 @@ assert('sum with multipul keys') do
   assert_include output, "[\"wiki.matsumoto-r.jp\", [[\"rcheckucpu\", 0.041994]]]\n[\"blog.matsumoto-r.jp\", [[\"rcheckucpu\", 16.506491]]]\n[\"moblog.matsumoto-r.jp\", [[\"rcheckucpu\", 5.637144]]]\n"
 end
 
-# TODO: support stdin on darwin
-unless RUBY_PLATFORM != "x86_64-darwin14"
-  assert('sum with multipul keys using stdin') do
-    stdin_log, status = Open3.capture2("tail", "-n", "100", LOG_PATH)
-    output, status = Open3.capture2(BIN_PATH, "stdin", "0", "hostname", "result.rcheckucpu", "sum", :stdin_data => stdin_log)
+assert('sum with multipul keys using stdin') do
+  stdin_log, status = Open3.capture2("tail", "-n", "100", LOG_PATH)
+  output, status = Open3.capture2(BIN_PATH, "stdin", "0", "hostname", "result.rcheckucpu", "sum", :stdin_data => stdin_log)
 
-    assert_true status.success?, "Process did not exit cleanly"
-    assert_include output, "[\"blog.matsumoto-r.jp\", [[\"rcheckucpu\", 16.107551]]]\n[\"moblog.matsumoto-r.jp\", [[\"rcheckucpu\", 5.637144]]]\n[\"wiki.matsumoto-r.jp\", [[\"rcheckucpu\", 0.041994]]]\n"
-  end
+  assert_true status.success?, "Process did not exit cleanly"
+  assert_include output, "[\"blog.matsumoto-r.jp\", [[\"rcheckucpu\", 16.107551]]]\n[\"moblog.matsumoto-r.jp\", [[\"rcheckucpu\", 5.637144]]]\n[\"wiki.matsumoto-r.jp\", [[\"rcheckucpu\", 0.041994]]]\n"
 end
 
 assert('version') do

--- a/bintest/rcheck-analyzer.rb
+++ b/bintest/rcheck-analyzer.rb
@@ -55,6 +55,13 @@ assert('hostname') do
   assert_include output, "[\"blog.matsumoto-r.jp\", 70]\n[\"moblog.matsumoto-r.jp\", 26]\n[\"wiki.matsumoto-r.jp\", 5]\n"
 end
 
+assert('big line analyze') do
+  output, status = Open3.capture2(BIN_PATH, LOG_PATH, "0", "method")
+
+  assert_true status.success?, "Process did not exit cleanly"
+  assert_include output, "[\"get\", 64742]\n[\"post\", 61065]\n[\"options\", 32]\n[\"head\", 5]\n"
+end
+
 assert('multipul keys') do
   output, status = Open3.capture2(BIN_PATH, LOG_PATH, "100", "hostname", "status")
 

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,12 +1,7 @@
 def gem_config(conf)
-  conf.gembox 'full-core'
-  conf.gem :mgem => 'mruby-dir'
+  conf.gembox 'default'
   conf.gem :mgem => 'mruby-json'
   conf.gem :mgem => 'mruby-io'
-  conf.gem :mgem => 'mruby-process'
-  conf.gem :mgem => 'mruby-env'
-  conf.gem :mgem => 'mruby-mutex'
-  conf.gem :mgem => 'mruby-regexp-pcre'
   conf.gem :github => "kou/mruby-pp"
 
   # be sure to include this gem (the cli app)
@@ -17,86 +12,7 @@ MRuby::Build.new do |conf|
   toolchain :gcc
 
   conf.enable_bintest
-  conf.enable_debug
   conf.enable_test
 
   gem_config(conf)
 end
-
-MRuby::Build.new('x86_64-pc-linux-gnu') do |conf|
-  toolchain :gcc
-
-  gem_config(conf)
-end
-
-#MRuby::CrossBuild.new('i686-pc-linux-gnu') do |conf|
-#  toolchain :gcc
-#
-#  [conf.cc, conf.cxx, conf.linker].each do |cc|
-#    cc.flags << "-m32"
-#  end
-#
-#  gem_config(conf)
-#end
-#
-#MRuby::CrossBuild.new('x86_64-apple-darwin14') do |conf|
-#  toolchain :clang
-#
-#  [conf.cc, conf.linker].each do |cc|
-#    cc.command = 'x86_64-apple-darwin14-clang'
-#  end
-#  conf.cxx.command      = 'x86_64-apple-darwin14-clang++'
-#  conf.archiver.command = 'x86_64-apple-darwin14-ar'
-#
-#  conf.build_target     = 'x86_64-pc-linux-gnu'
-#  conf.host_target      = 'x86_64-apple-darwin14'
-#
-#  gem_config(conf)
-#end
-#
-#MRuby::CrossBuild.new('i386-apple-darwin14') do |conf|
-#  toolchain :clang
-#
-#  [conf.cc, conf.linker].each do |cc|
-#    cc.command = 'i386-apple-darwin14-clang'
-#  end
-#  conf.cxx.command      = 'i386-apple-darwin14-clang++'
-#  conf.archiver.command = 'i386-apple-darwin14-ar'
-#
-#  conf.build_target     = 'i386-pc-linux-gnu'
-#  conf.host_target      = 'i386-apple-darwin14'
-#
-#  gem_config(conf)
-#end
-#
-#MRuby::CrossBuild.new('x86_64-w64-mingw32') do |conf|
-#  toolchain :gcc
-#
-#  [conf.cc, conf.linker].each do |cc|
-#    cc.command = 'x86_64-w64-mingw32-gcc'
-#  end
-#  conf.cxx.command      = 'x86_64-w64-mingw32-cpp'
-#  conf.archiver.command = 'x86_64-w64-mingw32-gcc-ar'
-#  conf.exts.executable  = ".exe"
-#
-#  conf.build_target     = 'x86_64-pc-linux-gnu'
-#  conf.host_target      = 'x86_64-w64-mingw32'
-#
-#  gem_config(conf)
-#end
-#
-#MRuby::CrossBuild.new('i686-w64-mingw32') do |conf|
-#  toolchain :gcc
-#
-#  [conf.cc, conf.linker].each do |cc|
-#    cc.command = 'i686-w64-mingw32-gcc'
-#  end
-#  conf.cxx.command      = 'i686-w64-mingw32-cpp'
-#  conf.archiver.command = 'i686-w64-mingw32-gcc-ar'
-#  conf.exts.executable  = ".exe"
-#
-#  conf.build_target     = 'i686-pc-linux-gnu'
-#  conf.host_target      = 'i686-w64-mingw32'
-#
-#  gem_config(conf)
-#end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -6,14 +6,10 @@ MRuby::Gem::Specification.new('rcheck-analyzer') do |spec|
 
   spec.add_test_dependency 'mruby-print', :core => 'mruby-print'
   spec.add_test_dependency 'mruby-enum-ext', :core => 'mruby-enum-ext'
+  spec.add_test_dependency 'mruby-exit', :core => 'mruby-exit'
   spec.add_test_dependency 'mruby-mtest', :mgem => 'mruby-mtest'
-  spec.add_test_dependency 'mruby-dir', :mgem => 'mruby-dir'
   spec.add_test_dependency 'mruby-json', :mgem => 'mruby-json'
   spec.add_test_dependency 'mruby-io', :mgem => 'mruby-io'
-  spec.add_test_dependency 'mruby-process', :mgem => 'mruby-process'
-  spec.add_test_dependency 'mruby-env', :mgem => 'mruby-env'
-  spec.add_test_dependency 'mruby-mutex', :mgem => 'mruby-mutex'
-  spec.add_test_dependency 'mruby-regexp-pcre', :mgem => 'mruby-regexp-pcre'
   spec.add_test_dependency 'mruby-pp', :github => "kou/mruby-pp"
 
 end

--- a/mrblib/rcheck-analyzer/analyze.rb
+++ b/mrblib/rcheck-analyzer/analyze.rb
@@ -21,34 +21,44 @@ module RcheckAnalyzer
     end
 
     def run
-      data = Data.data_from_log @log, @key1, @total_line
-      result = analyze_data data
+      result = {}
+      Data.each_data_from_log @log, @key1, @total_line do |line|
+        analyze_data_line line, result
+      end
       Message.output_result result, @multi_keys
+    end
+
+    def analyze_data_line d, analyze
+      create_analyze_data d, analyze
     end
 
     def analyze_data data
       analyze = {}
       data.each do |d|
-        if @key2.nil?
-          analyze[d[@key1]] = 0 if analyze[d[@key1]].nil?
-          analyze[d[@key1]] += 1
-        else
-          analyze[d[@key1]] = {} if analyze[d[@key1]].nil?
-          if @type == "sum"
-            if @key2_ary.nil?
-              analyze[d[@key1]][@key2] = 0 if analyze[d[@key1]][@key2].nil?
-              analyze[d[@key1]][@key2] += d[@key2].to_f
-            else
-              analyze[d[@key1]][@key2_ary[1]] = 0 if analyze[d[@key1]][@key2_ary[1]].nil?
-              analyze[d[@key1]][@key2_ary[1]] += d[@key2_ary[0]][@key2_ary[1]].to_f
-            end
-          else
-            analyze[d[@key1]][d[@key2]] = 0 if analyze[d[@key1]][d[@key2]].nil?
-            analyze[d[@key1]][d[@key2]] += 1
-          end
-        end
+        create_analyze_data d, analyze
       end
       analyze
+    end
+
+    def create_analyze_data d, analyze
+      if @key2.nil?
+        analyze[d[@key1]] = 0 if analyze[d[@key1]].nil?
+        analyze[d[@key1]] += 1
+      else
+        analyze[d[@key1]] = {} if analyze[d[@key1]].nil?
+        if @type == "sum"
+          if @key2_ary.nil?
+            analyze[d[@key1]][@key2] = 0 if analyze[d[@key1]][@key2].nil?
+            analyze[d[@key1]][@key2] += d[@key2].to_f
+          else
+            analyze[d[@key1]][@key2_ary[1]] = 0 if analyze[d[@key1]][@key2_ary[1]].nil?
+            analyze[d[@key1]][@key2_ary[1]] += d[@key2_ary[0]][@key2_ary[1]].to_f
+          end
+        else
+          analyze[d[@key1]][d[@key2]] = 0 if analyze[d[@key1]][d[@key2]].nil?
+          analyze[d[@key1]][d[@key2]] += 1
+        end
+      end
     end
   end
 end

--- a/mrblib/rcheck-analyzer/analyze.rb
+++ b/mrblib/rcheck-analyzer/analyze.rb
@@ -22,9 +22,12 @@ module RcheckAnalyzer
 
     def run
       result = {}
+      #data = []
       Data.each_data_from_log @log, @key1, @total_line do |line|
         analyze_data_line line, result
+        #data << line
       end
+      #result = analyze_data data
       Message.output_result result, @multi_keys
     end
 

--- a/mrblib/rcheck-analyzer/analyze.rb
+++ b/mrblib/rcheck-analyzer/analyze.rb
@@ -14,7 +14,7 @@ module RcheckAnalyzer
           end
         end
         @multi_keys = (@key2.nil?) ? false : true
-        @log = "/proc/self/fd/0" if @log == "stdin" or @log == "self"
+        @log = Data::STDIN_FD if @log == "stdin" or @log == "self"
       rescue => e
         raise ArgumentError, "invalid argument\n#{Error::USAGE}"
       end

--- a/mrblib/rcheck-analyzer/data.rb
+++ b/mrblib/rcheck-analyzer/data.rb
@@ -1,10 +1,11 @@
 module RcheckAnalyzer
   module Data
+    STDIN_FD = "/dev/fd/0"
     def self.each_data_from_log log, key, total_line
       read_line = 0
       data_line = nil
       File.open(log, "r") do |file|
-        unless log == "/proc/self/fd/0"
+        unless log == STDIN_FD
           fp = Tail.new file
         else
           fp = file

--- a/mrblib/rcheck-analyzer/data.rb
+++ b/mrblib/rcheck-analyzer/data.rb
@@ -1,5 +1,26 @@
 module RcheckAnalyzer
   module Data
+    def self.each_data_from_log log, key, total_line
+      read_line = 0
+      data_line = nil
+      File.open(log, "r") do |file|
+        unless log == "/proc/self/fd/0"
+          fp = Tail.new file
+        else
+          fp = file
+        end
+        fp.each do |line|
+          if key == "keys"
+            pp JSON.parse(line)
+            exit 0
+          end
+          data_line = JSON.parse(line.downcase)
+          yield data_line
+          read_line += 1
+          break if total_line != 0 and read_line > total_line
+        end
+      end
+    end
     def self.data_from_log log, key, total_line
       data = []
       File.open(log, "r") do |file|


### PR DESCRIPTION
Test passed, but abort if the number of `total_line` is big like 10000. why?

```
$ ./rchecker test/resource.log 10000 hostname
rchecker: /home/matsumotory/DEV/rcheck-analyzer/mruby/src/gc.c:1156: mrb_field_write_barrier: Assertion `!(((value)->color & ((mrb)->current_white_part ^ (1 | (1 << 1))) & (1 | (1 << 1))) || (value)->tt == MRB_TT_FREE) && !(((obj)->color & ((mrb)->current_white_part ^ (1 | (1 << 1))) & (1 | (1 << 1))) || (obj)->tt == MRB_TT_FREE)' failed.
Aborted
```

abort() don't occur by https://github.com/matsumoto-r/rcheck-analyzer/commit/00b1c73f5c660ccd7354ff54927140908f150888
### before

```
./mruby/bin/rcheck-analyzer test/resource.log 0 hostname
```
- peak memory

`1063` MiB

```
matsumoto_r     59524 100.0  6.3  3507480 1063972 s012  R+    4:54PM   0:09.24 ./mruby/bin/rcheck-analyzer test/resource.log 0 hostname
```
### after

```
./mruby/bin/rcheck-analyzer test/resource.log 0 hostname
```
- peak memory

`5`Mib

```
matsumoto_r     59921 100.0  0.0  2461120   5792 s012  R+    4:56PM   0:03.46 ./mruby/bin/rcheck-analyzer test/resource.log 0 hostname
```
